### PR TITLE
修复了几个Admin页面的错误，重写了部分路由

### DIFF
--- a/routes/controller/admin.js
+++ b/routes/controller/admin.js
@@ -19,18 +19,27 @@ function showerr(err, object) {
     }
 }
 // universal page query
+// page
+// | pageNumber
+// | pageCount
+// | results
 var pageQuery = function(page, pageSize, Model, populate, queryParams, sortParams, callback) {
-  var start = (page - 1) * pageSize;
+  page = parseInt(page);
   var $page = {
     pageNumber: page
   };
-  async.parallel({
-    count: function(done) {
+  async.waterfall([
+    function(done) {
       Model.count(queryParams).exec(function (err, count) {
         done(err, count);
       });
     },
-    records: function(done) {
+    function(count, done) {
+      $page.pageCount = parseInt((count - 1) / pageSize) + 1;
+      if (page > $page.pageCount) page = $page.pageCount;
+      if (page < 1) page = 1;
+      $page.pageNumber = page;
+      var start = (page - 1) * pageSize;
       Model.find(queryParams)
         .skip(start)
         .limit(pageSize)
@@ -40,14 +49,13 @@ var pageQuery = function(page, pageSize, Model, populate, queryParams, sortParam
           done(err, doc);
         });
     }
-  }, function(err, results) {
-    var count = results.count;
-    $page.pageCount = (count - 1) / pageSize + 1;
-    $page.results = results.records;
+  ], function(err, doc) {
+    $page.results = doc;
     callback(err, $page);
   });
 }
 
+// login function isnot finished
 // login page
 router.get('/', function(req, res, next) {
   res.render('admin/login', { title: '管理员登录' });
@@ -61,12 +69,11 @@ router.post('/portal', function(req, res, next) {
 // news create update delete
 // req.body.mode = "create" | "update" | "delete"
 // req.body.content
-//   id, title, content, type, create_time, author
+// | id, title, content, type, create_time, author
 router.post('/newsdb', function(req, res, next) {
   var rdoc = req.body;
   if (rdoc.mode == 'delete') {
-    // console.log('deleting news no.' + rdoc._id);
-    nojdb.news.remove({ _id: rdoc._id }, showerr);
+    nojdb.news.remove({ _id: rdoc.id }, showerr);
   }else if (rdoc.mode == 'create') {
     var model = {
       title: rdoc.title,
@@ -82,18 +89,17 @@ router.post('/newsdb', function(req, res, next) {
       type: rdoc.type,
       author: "root"
     };
-    nojdb.news.update({ _id: rdoc._id }, model, showerr);
+    nojdb.news.update({ _id: rdoc.id }, model, showerr);
   }
   res.redirect("/admin/news");
 });
 
 // admin pages
 router.get('/news', function(req, res, next) {
-  // page
   var qdoc = req.query;
   var page = qdoc.page ? parseInt(qdoc.page) : 1;
-  // var pageSize = qdoc.pageSize ? parseInt(qdoc.pageSize) : 10;
-  pageQuery(page, 10, nojdb.news, '', '', { 'create_time': -1 }, function(err, results) {
+  var pageSize = 20;
+  pageQuery(page, pageSize, nojdb.news, '', '', { 'create_time': -1 }, function(err, results) {
     // set time format
     results.results.forEach(function (x) {
       x.create_time_string = moment(x.create_time).format(timeFormat);
@@ -109,34 +115,82 @@ router.get('/news', function(req, res, next) {
   });
 });
 router.get('/contest', function(req, res, next) {
-  res.render('admin/index', { title: '比赛管理', status: 'contest' });
+  var qdoc = req.query;
+  var page = qdoc.page ? parseInt(qdoc.page) : 1;
+  var pageSize = 20;
+  pageQuery(page, pageSize, nojdb.contest, '', '', { 'create_time': -1 }, function(err, results) {
+    // set time format
+    results.results.forEach(function (x) {
+      x.create_time_string = moment(x.begin_time).format(timeFormat);
+      x.create_time_string = moment(x.end_time).format(timeFormat);
+      x.create_time_string = moment(x.create_time).format(timeFormat);
+    });
+    res.render(
+      'admin/index',
+      { 
+        title: '比赛管理', 
+        status: 'contest',
+        page: results
+      }
+    );
+  });
 });
 router.get('/problem', function(req, res, next) {
-  res.render('admin/index', { title: '题目管理', status: 'problem' });
+  var qdoc = req.query;
+  var page = qdoc.page ? parseInt(qdoc.page) : 1;
+  var pageSize = 20;
+  pageQuery(page, pageSize, nojdb.question, '', '', { 'create_time': -1 }, function(err, results) {
+    // set time format
+    results.results.forEach(function (x) {
+      x.create_time_string = moment(x.create_time).format(timeFormat);
+    });
+    res.render(
+      'admin/index',
+      { 
+        title: '题目管理', 
+        status: 'problem',
+        page: results
+      }
+    );
+  });
+});
+
+// create pages
+router.get('/create/news', function(req, res, next) {
+  var context = {
+    _id: -1,
+    title: '创建公告',
+    mode: 'create',
+    model: {
+      title: '',
+      content: ''
+    }
+  };
+  res.render('admin/edit_news', context);
+});
+router.get('/create/problem', function(req, res, next) {
+  res.render('admin/edit_problem', { title: '创建题目'});
+});
+router.get('/create/contest', function(req, res, next) {
+  res.render('admin/edit_contest', { title: '创建比赛'});
 });
 
 // edit pages
 router.get('/edit/news', function(req, res, next) {
   var rdoc = req.query;
   var context = {
-    _id: -1,
-    mode: rdoc.mode,
+    _id: rdoc.id,
+    mode: 'update',
+    title: '编辑公告',
     model: {
       title: '',
       content: ''
     }
   };
-  if (rdoc.mode == 'create') {
-    context.title = '创建公告';
+  nojdb.news.findOne({ _id: context._id }, function(err, model) {
+    context.model = model;
     res.render('admin/edit_news', context);
-  }else if (rdoc.mode == 'update') {
-    context.title = '编辑公告';
-    context._id = rdoc._id;
-    nojdb.news.findOne({ _id: context._id }, function(err, model) {
-      context.model = model;
-      res.render('admin/edit_news', context);
-    });
-  }
+  });
 });
 router.get('/edit/contest', function(req, res, next) {
   res.render('admin/edit_contest', { title: '编辑比赛'});

--- a/views/admin/edit_news.pug
+++ b/views/admin/edit_news.pug
@@ -15,7 +15,8 @@ block content
           textarea.form-control(name='content' rows='3' placeholder="请输入内容") #{model.content}
         hr
         p
-          a.pull-right.btn.btn-danger(href="/admin/news" onclick="$.post('/admin/newsdb', { mode: 'delete', _id: '" + _id + "' });") 删除此条公告
+          - if (mode == "update")
+            a.pull-right.btn.btn-danger(href="/admin/news" onclick="$.post('/admin/newsdb', { mode: 'delete', id: '" + _id + "' });") 删除此条公告
           span.pull-right &nbsp; &nbsp;
           a.pull-right.btn.btn-primary( href="/admin/news") 放弃编辑
           button.btn.btn-success() 提交

--- a/views/admin/index.pug
+++ b/views/admin/index.pug
@@ -17,11 +17,11 @@ block content
     .list-group
       a.list-group-item(href="/") 站点首页
   .col-xs-9#sub-pages
-    h3#page-title
+    h3 #{title}
     - if (status == 'news') {
       div#news
         p
-          a.btn.btn-success(href="/admin/edit/news?mode=create") 新建公告
+          a.btn.btn-success(href="/admin/create/news") 新建公告
         .panel.panel-default
           table.table.table-striped
             thead
@@ -39,63 +39,57 @@ block content
                   td #{val.create_time_string}
                   td -
                   td 
-                    a(href="/admin/edit/news?mode=update&_id=" + val._id) 修改
+                    a(href="/admin/edit/news?id=" + val._id) 修改
                     span &nbsp;&nbsp;
-                    a(href="" onclick="$.post('/admin/newsdb', { mode: 'delete', _id: '" + val._id + "' });") 删除
+                    a(href="" onclick="$.post('/admin/newsdb', { mode: 'delete', id: '" + val._id + "' });") 删除
     - }
     - if (status == 'problem') {
       div#problem
         p
-          a.btn.btn-success(href="/admin/edit/problem") 新建题目
-        .panel.panel-default
-          .panel-body 共计#个题目
+          a.btn.btn-success(href="/admin/create/problem") 新建题目
         .panel.panel-default
           table.table.table-striped
             thead
               tr
-                th #
                 th 标题
                 th 状态
                 th 操作
             tbody
-              tr
-                td 1
-                td
-                  a(href="") A+B
-                td 243/244
-                td
-                  a(href="/admin/edit/problem") 修改
-                  span &nbsp;&nbsp;
-                  a(href="") 删除
+              - for (x in page.results)
+                tr
+                  td
+                    a(href="#") x.title
+                  td #{x.correct_submit}/#{x.submit_total}
+                  td
+                    a(href="/admin/edit/problem?id=" + x._id) 修改
+                    span &nbsp;&nbsp;
+                    a(href="") 删除
     - }
     - if (status == 'contest') {
       div#contest
         p
-          a.btn.btn-success(href="/admin/edit/contest") 新建比赛
-        .panel.panel-default
-          .panel-body 共计#场比赛
+          a.btn.btn-success(href="/admin/create/contest") 新建比赛
         .panel.panel-default
           table.table.table-striped
             thead
               tr
-                th #
                 th 比赛
                 th 开始时间
                 th 结束时间
                 th 状态
                 th 操作
             tbody
-              tr
-                td 3
-                td 
-                  a(href="") NWPU-Weekly-03
-                td 2016/10/5 20:00
-                td 2016/10/5 22:00
-                td 未开始
-                td 
-                  a(href="/admin/edit/contest") 修改
-                  span &nbsp;&nbsp;
-                  a(href="") 删除
+              - for (x in page.results)
+                tr
+                  td 
+                    a(href="") #{x.title}
+                  td #{x.begin_time}
+                  td #{x.end_time}
+                  td 未开始
+                  td 
+                    a(href="/admin/edit/contest?id=" + x._id) 修改
+                    span &nbsp;&nbsp;
+                    a(href="") 删除
     - }
     nav
       ul.pagination


### PR DESCRIPTION
# 修复错误
- 取消了/create/news（添加公告）当中的“删除本条记录”按钮，因为不符合逻辑
- /admin/contest和/admin/problem页面显示错误的问题
- 显示列表的时候页码超出数据范围时自动返回最后一页或第一页（取决于pageNum过大还是过小）

# 路由修改
- 将新建公告/比赛/题目的地址转到了 /admin/create/下，如新建公告在/admin/create/news里面，和编辑页面/admin/edit/news作区分
- /newsdb仍然承担公告的增删改的功能，暂时不能提供返回信息（例如创建成功、失败等）
